### PR TITLE
chat-space 自動更新機能

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,8 @@ $(function(){
   function buildHTML(message){
     if ( message.image ) {
       var html =
-       `<div class="message">
+       //data-idが反映されるようにしている
+       `<div class="message" data-message-id=${message.id}>
           <div class="upper-message">
             <div class="upper-message__user-name">
               ${message.user_name}
@@ -21,7 +22,8 @@ $(function(){
       return html;
     } else {
       var html =
-       `<div class="message">
+       //data-idが反映されるようにしている
+       `<div class="message" data-message-id=${message.id}>
           <div class="upper-message">
             <div class="upper-message__user-name">
               ${message.user_name}
@@ -39,28 +41,70 @@ $(function(){
       return html;
     };
   }
-  
-  $('#new_message').on('submit', function(e){
-    e.preventDefault()
-    var formData = new FormData(this);
-    var url = $(this).attr('action');
+ 
+  $(function() {
+    $('#new_message').on('submit', function(e){
+
+      e.preventDefault()
+      var formData = new FormData(this);
+      var url = $(this).attr('action');
+      
+      $.ajax({
+        url: url,
+        type: 'POST',
+        data: formData,
+        dataType: 'json',
+        processData: false,
+        contentType: false
+      })
+      .done(function(data){
+        var html = buildHTML(data);
+        $('.main-contents').append(html);
+        $('form')[0].reset();
+        $('.main-contents').animate({ scrollTop: $('.main-contents')[0].scrollHeight});
+      })
+      .fail(function() {
+        alert("メッセージ送信に失敗しました");
+      })
+        // return false;
+    });
+  });
+
+      
+    //省略
+  var reloadMessages = function() {
+    
+        //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    var last_message_id = $('.message:last').data("message-id");
+
+
     $.ajax({
-      url: url,
-      type: 'POST',
-      data: formData,
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
       dataType: 'json',
-      processData: false,
-      contentType: false
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
     })
-    .done(function(data){
-      var html = buildHTML(data);
-      $('.main-contents').append(html);
-      $('form')[0].reset();
+    .done(function(messages) {
+      if (messages.length !== 0) {
+      //追加するHTMLの入れ物を作る
+      var insertHTML = '';
+      //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      //メッセージが入ったHTMLに、入れ物ごと追加
+      $('.main-contents').append(insertHTML);
       $('.main-contents').animate({ scrollTop: $('.main-contents')[0].scrollHeight});
+    }
     })
     .fail(function() {
-      alert("メッセージ送信に失敗しました");
-  });
-      return false;
-  });
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image_url
+  json.user_name message.user.name
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data:{message:{id: message.id}}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
   resources :users, only: [:index, :edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update] do
+  resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+#追加
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#what
chatspaceに自動更新機能の追加
リロードをすることなく新規メッセージの取得可能。
ルーティング、コントローラー、jbuilder、対応するアクションを追加。

#why
コミュニケーションの円滑化

実装動画
https://gyazo.com/40741770f88b11ee8e1bf5dfff48e082
https://gyazo.com/d531bda41c077c8aac4452fafd974376
https://gyazo.com/7ece91f55baecf784f882fda172c387c